### PR TITLE
Move secondary nav items to sidebar

### DIFF
--- a/includes/Admin/Setup.php
+++ b/includes/Admin/Setup.php
@@ -65,10 +65,8 @@ class Setup {
 	 * @since 1.0.0
 	 */
 	public function register_scripts() {
-		error_log('register_scripts called on page: ' . $_SERVER['REQUEST_URI']);
-
 		// Only load on WooCommerce admin pages
-		if ( !is_admin() || ! class_exists( 'WooCommerce' ) ) {
+		if ( ! is_admin() || ! class_exists( 'WooCommerce' ) ) {
 			return;
 		}
 
@@ -81,9 +79,6 @@ class Setup {
 			'version'      => filemtime( $script_path ),
 		);
 		$script_url        = plugins_url( $script_path, MAIN_PLUGIN_FILE );
-
-		error_log('Registering script with URL: ' . $script_url);
-		error_log('Script dependencies: ' . print_r($script_asset['dependencies'], true));
 
 		wp_register_script(
 			'settings-tester',

--- a/includes/Admin/Setup.php
+++ b/includes/Admin/Setup.php
@@ -65,9 +65,10 @@ class Setup {
 	 * @since 1.0.0
 	 */
 	public function register_scripts() {
-		if ( ! method_exists( 'Automattic\WooCommerce\Admin\PageController', 'is_admin_or_embed_page' ) ||
-		! \Automattic\WooCommerce\Admin\PageController::is_admin_or_embed_page()
-		) {
+		error_log('register_scripts called on page: ' . $_SERVER['REQUEST_URI']);
+
+		// Only load on WooCommerce admin pages
+		if ( !is_admin() || ! class_exists( 'WooCommerce' ) ) {
 			return;
 		}
 
@@ -81,10 +82,13 @@ class Setup {
 		);
 		$script_url        = plugins_url( $script_path, MAIN_PLUGIN_FILE );
 
+		error_log('Registering script with URL: ' . $script_url);
+		error_log('Script dependencies: ' . print_r($script_asset['dependencies'], true));
+
 		wp_register_script(
 			'settings-tester',
 			$script_url,
-			$script_asset['dependencies'],
+			array_merge( $script_asset['dependencies'], array( 'wc-settings-editor' ) ),
 			$script_asset['version'],
 			true
 		);
@@ -92,7 +96,6 @@ class Setup {
 		wp_register_style(
 			'settings-tester',
 			plugins_url( '/build/index.css', MAIN_PLUGIN_FILE ),
-			// Add any dependencies styles may have, such as wp-components.
 			array(),
 			filemtime( dirname( MAIN_PLUGIN_FILE ) . '/build/index.css' )
 		);

--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
 	],
 	"dependencies": {
 		"@automattic/site-admin": "^0.0.1",
+		"@woocommerce/settings-editor": "^0.1.0",
 		"@wordpress/hooks": "^4.8.0",
 		"@wordpress/i18n": "^5.8.0"
 	},
 	"devDependencies": {
-		"@woocommerce/dependency-extraction-webpack-plugin": "^3.0.1",
+		"@woocommerce/dependency-extraction-webpack-plugin": "^3.1.0",
 		"@woocommerce/eslint-plugin": "^2.3.0",
 		"@wordpress/scripts": "^30.14.0"
 	}

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
 		"settings-tester.php"
 	],
 	"dependencies": {
+		"@automattic/site-admin": "^0.0.1",
 		"@wordpress/hooks": "^4.8.0",
 		"@wordpress/i18n": "^5.8.0"
 	},
 	"devDependencies": {
 		"@woocommerce/dependency-extraction-webpack-plugin": "^3.0.1",
 		"@woocommerce/eslint-plugin": "^2.3.0",
-		"@wordpress/scripts": "^24.6.0"
+		"@wordpress/scripts": "^30.14.0"
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { getQueryArgs } from '@wordpress/url';
+import { getQueryArgs, addQueryArgs } from '@wordpress/url';
+import { Sidebar } from '@woocommerce/settings-editor';
 
 /**
  * Internal dependencies
@@ -12,19 +13,70 @@ import './slotFill';
 
 export const ModernScreen = ( { section } ) => {
 	return (
-		<>
+		<div className="woocommerce-settings-content">
 			<h2>This is a modern screen</h2>
 			<p>Section: { section }</p>
-		</>
+		</div>
 	);
 };
 
 addFilter( 'woocommerce_admin_settings_pages', 'woocommerce', ( pages ) => {
 	const currentArgs = getQueryArgs( window.location.href );
 	const section = currentArgs.section ? currentArgs.section : 'mammals';
+	const backPath = addQueryArgs( 'wc-settings', {} );
+	const backLabel = 'Modern Settings';
+
+	const sidebarItems = [
+		{
+			slug: 'settings-tester-modern-screen-mammals',
+			label: 'Mammals',
+			icon: 'bug',
+			to: addQueryArgs( 'wc-settings', {
+				tab: 'settings-tester-modern-screen',
+				section: 'mammals',
+			} ),
+			withChevron: false,
+			isCurrent: section === 'mammals',
+			backLabel,
+			backPath,
+		},
+		{
+			slug: 'settings-tester-modern-screen-birds',
+			label: 'Birds',
+			icon: 'starEmpty',
+			to: addQueryArgs( 'wc-settings', {
+				tab: 'settings-tester-modern-screen',
+				section: 'birds',
+			} ),
+			withChevron: false,
+			isCurrent: section === 'birds',
+			backLabel,
+			backPath,
+		},
+		{
+			slug: 'settings-tester-modern-screen-fish',
+			label: 'Fish',
+			icon: 'color',
+			to: addQueryArgs( 'wc-settings', {
+				tab: 'settings-tester-modern-screen',
+				section: 'fish',
+			} ),
+			withChevron: false,
+			isCurrent: section === 'fish',
+			backLabel,
+			backPath,
+		},
+	];
 
 	pages[ 'settings-tester-modern-screen' ] = {
 		areas: {
+			sidebar: (
+				<Sidebar
+					routeKey={ 'settings-tester-modern-screen' }
+					sidebarItems={ sidebarItems }
+					currentNestLevel={ 1 }
+				/>
+			),
 			content: <ModernScreen section={ section } />,
 			edit: null,
 		},
@@ -33,5 +85,6 @@ addFilter( 'woocommerce_admin_settings_pages', 'woocommerce', ( pages ) => {
 			edit: 380,
 		},
 	};
+
 	return pages;
 } );


### PR DESCRIPTION
Move control of sidebar to extensions as part of changes made in https://github.com/woocommerce/woocommerce/pull/56885